### PR TITLE
Prevent invalid endpoints from being included in specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ app.register(fastifySwagger, {
   // You can also create transform with custom skiplist:
   //
   // transform: createJsonSchemaTransform({
-  //   skipList: [ '/documentation/static/{wildcard}' ]
+  //   skipList: [ '/documentation/static/*' ]
   // })
 });
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ app.listen({ port: 4949 });
 ```ts
 import {
   jsonSchemaTransform,
+  createJsonSchemaTransform,
   serializerCompiler,
   validatorCompiler,
   ZodTypeProvider,
@@ -58,6 +59,11 @@ app.register(fastifySwagger, {
     servers: [],
   },
   transform: jsonSchemaTransform,
+  // You can also create transform with custom skiplist:
+  //
+  // transform: createJsonSchemaTransform({
+  //   skipList: [ '/documentation/static/{wildcard}' ]
+  // })
 });
 
 const LOGIN_SCHEMA = z.object({

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ app.register(fastifySwagger, {
     servers: [],
   },
   transform: jsonSchemaTransform,
-  // You can also create transform with custom skiplist:
+  // You can also create transform with custom skiplist of endpoints that should not be included in the specification:
   //
   // transform: createJsonSchemaTransform({
   //   skipList: [ '/documentation/static/*' ]

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "fastify": "^4.3.0",
     "jest": "^28.1.3",
+    "oas-validator": "^5.0.8",
     "prettier": "^2.7.1",
     "ts-jest": "^28.0.7",
     "tsd": "^0.22.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,36 +3,57 @@ import type { FastifySerializerCompiler } from 'fastify/types/schema';
 import type { z, ZodAny, ZodTypeAny } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
+const defaultSkipList = [
+  '/documentation/',
+  '/documentation/initOAuth',
+  '/documentation/json',
+  '/documentation/uiConfig',
+  '/documentation/yaml',
+  '/documentation/*',
+  '/documentation/static/*',
+];
+
 export interface ZodTypeProvider extends FastifyTypeProvider {
   output: this['input'] extends ZodTypeAny ? z.infer<this['input']> : never;
 }
 
-export const jsonSchemaTransform = ({ schema, url }: { schema: FastifySchema; url: string }) => {
-  const { params, body, querystring, headers, response } = schema;
+export const createJsonSchemaTransform = ({ skipList }: { skipList: readonly string[] }) => {
+  return ({ schema, url }: { schema: FastifySchema; url: string }) => {
+    const { params, body, querystring, headers, response } = schema;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const transformed: Record<string, any> = {};
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (params) transformed.params = zodToJsonSchema(params as any);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (body) transformed.body = zodToJsonSchema(body as any);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (querystring) transformed.querystring = zodToJsonSchema(querystring as any);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (headers) transformed.headers = zodToJsonSchema(headers as any);
-
-  if (response) {
-    transformed.response = {};
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    for (const prop in response as any) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      transformed.response[prop] = zodToJsonSchema((response as any)[prop]);
-    }
-  }
+    const transformed: Record<string, any> = {};
 
-  return { schema: transformed, url };
+    if (skipList.includes(url)) {
+      transformed.hide = true;
+      return { schema: transformed, url };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (params) transformed.params = zodToJsonSchema(params as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (body) transformed.body = zodToJsonSchema(body as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (querystring) transformed.querystring = zodToJsonSchema(querystring as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (headers) transformed.headers = zodToJsonSchema(headers as any);
+
+    if (response) {
+      transformed.response = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for (const prop in response as any) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        transformed.response[prop] = zodToJsonSchema((response as any)[prop]);
+      }
+    }
+
+    return { schema: transformed, url };
+  };
 };
+
+export const jsonSchemaTransform = createJsonSchemaTransform({
+  skipList: defaultSkipList,
+});
 
 export const validatorCompiler: FastifySchemaCompiler<ZodAny> =
   ({ schema }) =>

--- a/test/__snapshots__/fastify-swagger.spec.ts.snap
+++ b/test/__snapshots__/fastify-swagger.spec.ts.snap
@@ -12,69 +12,6 @@ Object {
   },
   "openapi": "3.0.3",
   "paths": Object {
-    "/documentation/": Object {
-      "get": Object {
-        "responses": Object {
-          "200": Object {
-            "description": "Default Response",
-          },
-        },
-      },
-    },
-    "/documentation/initOAuth": Object {
-      "get": Object {
-        "responses": Object {
-          "200": Object {
-            "description": "Default Response",
-          },
-        },
-      },
-    },
-    "/documentation/json": Object {
-      "get": Object {
-        "responses": Object {
-          "200": Object {
-            "description": "Default Response",
-          },
-        },
-      },
-    },
-    "/documentation/static/{wildcard}": Object {
-      "get": Object {
-        "responses": Object {
-          "200": Object {
-            "description": "Default Response",
-          },
-        },
-      },
-    },
-    "/documentation/uiConfig": Object {
-      "get": Object {
-        "responses": Object {
-          "200": Object {
-            "description": "Default Response",
-          },
-        },
-      },
-    },
-    "/documentation/yaml": Object {
-      "get": Object {
-        "responses": Object {
-          "200": Object {
-            "description": "Default Response",
-          },
-        },
-      },
-    },
-    "/documentation/{wildcard}": Object {
-      "get": Object {
-        "responses": Object {
-          "200": Object {
-            "description": "Default Response",
-          },
-        },
-      },
-    },
     "/login": Object {
       "post": Object {
         "requestBody": Object {

--- a/test/fastify-swagger.spec.ts
+++ b/test/fastify-swagger.spec.ts
@@ -1,5 +1,6 @@
 import fastifySwagger from '@fastify/swagger';
 import Fastify from 'fastify';
+import validator = require('oas-validator');
 import { z } from 'zod';
 
 import type { ZodTypeProvider } from '../src';
@@ -56,5 +57,6 @@ describe('transformer', () => {
     const openApiSpec = JSON.parse(openApiSpecResponse.body);
 
     expect(openApiSpec).toMatchSnapshot();
+    await validator.validate(openApiSpec, {});
   });
 });


### PR DESCRIPTION
Previously unnecessary fastify-swagger endpoints ended up being included, and their wildcard variants messed up document completely, resulting in this:
```
  "/documentation/{wildcard}":
    get:
      responses:
        "200":
          description: Default Response
  "/documentation/static/{wildcard}":
    get:
      responses:
        "200":
          description: Default Response
  "{wildcard}":
    options:
      responses:
        "200":
          description: Default Response
```

Now they are excluded by default, and there is an option to provide custom skiplists if necessary.
We should probably also look into handling of "*" of normal routes within transformer, I suspect they will get broken as well.