### PR TITLE
Do not swallow response validation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "zod-to-json-schema": "^3.17.1"
   },
   "devDependencies": {
-    "@fastify/swagger": "^7.5.0",
+    "@fastify/swagger": "^7.5.1",
     "@types/jest": "^28.1.8",
-    "@types/node": "^18.7.14",
-    "@typescript-eslint/eslint-plugin": "^5.36.1",
-    "@typescript-eslint/parser": "^5.36.1",
+    "@types/node": "^18.7.15",
+    "@typescript-eslint/eslint-plugin": "^5.36.2",
+    "@typescript-eslint/parser": "^5.36.2",
     "eslint": "^8.23.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",


### PR DESCRIPTION
Previously we would be discarding actual validation results and only return fixed text