### PR TITLE
Fix/fastify swagger bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ app.listen({ port: 4949 });
 ## How to use together with @fastify/swagger
 
 ```ts
+import fastify from 'fastify';
+import fastifySwagger from '@fastify/swagger';
+import fastifySwaggerUI from '@fastify/swagger-ui';
+import { z } from 'zod';
+
 import {
   jsonSchemaTransform,
   createJsonSchemaTransform,
@@ -48,12 +53,11 @@ import {
   ZodTypeProvider,
 } from 'fastify-type-provider-zod';
 
-const app = Fastify();
+const app = fastify();
 app.setValidatorCompiler(validatorCompiler);
 app.setSerializerCompiler(serializerCompiler);
 
 app.register(fastifySwagger, {
-  exposeRoute: true,
   openapi: {
     info: {
       title: 'SampleApi',
@@ -70,8 +74,12 @@ app.register(fastifySwagger, {
   // })
 });
 
+app.register(fastifySwaggerUI, {
+  routePrefix: '/documentation',
+});
+
 const LOGIN_SCHEMA = z.object({
-  username: z.string().max(32).describe('someDescription'),
+  username: z.string().max(32).describe('Some description for username'),
   password: z.string().max(32),
 });
 
@@ -86,5 +94,15 @@ app.after(() => {
   });
 });
 
-await app.ready();
+async function run() {
+  await app.ready();
+
+  await app.listen({
+    port: 4949,
+  });
+
+  console.log(`Documentation running at http://localhost:4949/documentation`);
+}
+
+run();
 ```

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "zod-to-json-schema": "^3.17.1"
   },
   "devDependencies": {
-    "@fastify/swagger": "^7.5.1",
+    "@fastify/swagger": "^8.2.0",
+    "@fastify/swagger-ui": "^1.3.0",
     "@types/jest": "^29.2.0",
     "@types/node": "^18.11.7",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
@@ -46,13 +47,14 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "fastify": "^4.9.2",
+    "fastify": "^4.10.2",
     "jest": "^29.2.2",
     "oas-validator": "^5.0.8",
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "tsd": "^0.24.1",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "zod": "^3.19.1"
   },
   "tsd": {
     "directory": "types"

--- a/test/fastify-swagger.spec.ts
+++ b/test/fastify-swagger.spec.ts
@@ -1,7 +1,8 @@
 import fastifySwagger from '@fastify/swagger';
+import fastifySwaggerUI from '@fastify/swagger-ui';
 import Fastify from 'fastify';
-import validator = require('oas-validator');
 import { z } from 'zod';
+const validator = require('oas-validator');
 
 import type { ZodTypeProvider } from '../src';
 import { jsonSchemaTransform, serializerCompiler, validatorCompiler } from '../src';
@@ -13,7 +14,6 @@ describe('transformer', () => {
     app.setSerializerCompiler(serializerCompiler);
 
     app.register(fastifySwagger, {
-      exposeRoute: true,
       openapi: {
         info: {
           title: 'SampleApi',
@@ -23,6 +23,10 @@ describe('transformer', () => {
         servers: [],
       },
       transform: jsonSchemaTransform,
+    });
+
+    app.register(fastifySwaggerUI, {
+      routePrefix: '/documentation',
     });
 
     const LOGIN_SCHEMA = z.object({

--- a/test/fastify-swagger.spec.ts
+++ b/test/fastify-swagger.spec.ts
@@ -1,8 +1,8 @@
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUI from '@fastify/swagger-ui';
 import Fastify from 'fastify';
+import * as validator from 'oas-validator';
 import { z } from 'zod';
-const validator = require('oas-validator');
 
 import type { ZodTypeProvider } from '../src';
 import { jsonSchemaTransform, serializerCompiler, validatorCompiler } from '../src';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "declaration": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true
   },
   "exclude": ["./node_modules", "types/**/*.test-d.ts", "test", "dist"]
 }


### PR DESCRIPTION
This branch aims to bring `@fastify/swagger` into its latest version, going through a breaking change on `@^8` that splits the package into `@fastify/swagger` and `@fastify/swagger-ui`.

Also, adds `zod` as a `devDependency` (required for testing), fixes a missing interop on the tsconfig and fixes the example on README.md.