### PR TITLE
Update zod-to-json-schema to latest version, expose zod-to-json-schema options on createJsonSchemaTransform

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/turkerdev/fastify-type-provider-zod",
   "dependencies": {
-    "zod-to-json-schema": "^3.22.0"
+    "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {
     "@fastify/swagger": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "test": "npm run build && npm run typescript && jest",
     "test:coverage": "jest --coverage",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/turkerdev/fastify-type-provider-zod",
   "dependencies": {
-    "zod-to-json-schema": "^3.17.1"
+    "zod-to-json-schema": "^3.22.0"
   },
   "devDependencies": {
     "@fastify/swagger": "^8.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,15 @@
     "declaration": true,
     "rootDir": "src",
     "outDir": "dist",
+    "target": "es2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true
   },
-  "exclude": ["./node_modules", "types/**/*.test-d.ts", "test", "dist"]
+  "exclude": [
+    "./node_modules",
+    "types/**/*.test-d.ts",
+    "test",
+    "dist"
+  ]
 }


### PR DESCRIPTION
This will be very useful, for example modifying the contentEncoding for binary files when using a `z.string().base64()` with latest zod(3.23)