### PR TITLE
fix(types): allow assigning provider-enabled instances to `FastifyInstance`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const defaultSkipList = [
 ];
 
 export interface ZodTypeProvider extends FastifyTypeProvider {
-  output: this['input'] extends ZodTypeAny ? z.infer<this['input']> : never;
+  output: this['input'] extends ZodTypeAny ? z.infer<this['input']> : unknown;
 }
 
 interface Schema extends FastifySchema {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "declaration": true,
     "rootDir": "src",
     "outDir": "dist",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "exclude": ["./node_modules", "types/**/*.test-d.ts", "test", "dist"]
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -25,6 +25,7 @@ type FastifyZodInstance = FastifyInstance<
 expectType<FastifyZodInstance>(fastify.setValidatorCompiler(validatorCompiler));
 expectType<FastifyZodInstance>(fastify.setSerializerCompiler(serializerCompiler));
 expectAssignable<FastifyZodInstance>(fastify);
+expectAssignable<FastifyInstance>(fastify);
 
 fastify.route({
   method: 'GET',


### PR DESCRIPTION
Fixes fastify/aws-lambda-fastify#205 by making `ZodTypeProvider` assignable to `FastifyTypeProvider`.

For an explanation, see https://fastify.dev/docs/latest/Guides/Write-Type-Provider/.