### PR TITLE
feat: type definition for separated type provider for fastify 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "fastify": "^4.0.0",
+    "fastify": "next",
     "zod": "^3.14.2"
   },
   "repository": {
@@ -49,7 +49,6 @@
     "@typescript-eslint/parser": "^7.9.0",
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
-    "fastify": "^4.27.0",
     "fastify-plugin": "^4.5.1",
     "jest": "^29.7.0",
     "oas-validator": "^5.0.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,8 @@ const defaultSkipList = [
 ];
 
 export interface ZodTypeProvider extends FastifyTypeProvider {
-  output: this['input'] extends ZodTypeAny ? z.infer<this['input']> : unknown;
+  validator: this['schema'] extends ZodTypeAny ? z.infer<this['schema']> : unknown;
+  serializer: this['schema'] extends ZodTypeAny ? z.infer<this['schema']> : unknown;
 }
 
 interface Schema extends FastifySchema {


### PR DESCRIPTION
The interface `TypeProvider` changed in Fastify 5. Look at https://github.com/fastify/fastify/pull/5427
This PR adjusts the `ZodTypeProvider` implementation.

It's a break change