### PR TITLE
feat: added refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,6 @@ app.register(fastifySwagger, {
   // transform: createJsonSchemaTransform({
   //   skipList: [ '/documentation/static/*' ]
   // })
-
-  // In order to create refs to the schemas, you need to provide the schemas to the transformObject using createJsonSchemaTransformObject
-  //
-  // transformObject: createJsonSchemaTransformObject({
-  //    schemas: {
-  //      User: z.object({
-  //        id: z.string(),
-  //        name: z.string(),
-  //      }),
-  //    }
-  // }),
 });
 
 app.register(fastifySwaggerUI, {
@@ -102,6 +91,80 @@ app.after(() => {
     schema: { body: LOGIN_SCHEMA },
     handler: (req, res) => {
       res.send('ok');
+    },
+  });
+});
+
+async function run() {
+  await app.ready();
+
+  await app.listen({
+    port: 4949,
+  });
+
+  console.log(`Documentation running at http://localhost:4949/documentation`);
+}
+
+run();
+```
+
+## How to create refs to the schemas?
+It is possible to create refs to the schemas by using the `createJsonSchemaTransformObject` function. You provide the schemas as an object and fastifySwagger will create a OpenAPI document in which the schemas are referenced. The following example creates a ref to the `User` schema and will include the `User` schema in the OpenAPI document.
+
+```ts
+import fastifySwagger from '@fastify/swagger';
+import fastifySwaggerUI from '@fastify/swagger-ui';
+import fastify from 'fastify';
+import { z } from 'zod';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import {
+  createJsonSchemaTransformObject,
+  jsonSchemaTransform,
+  serializerCompiler,
+  validatorCompiler,
+} from 'fastify-type-provider-zod';
+
+const USER_SCHEMA = z.object({
+  id: z.number().int().positive(),
+  name: z.string().describe('The name of the user'),
+});
+
+const app = fastify();
+app.setValidatorCompiler(validatorCompiler);
+app.setSerializerCompiler(serializerCompiler);
+
+app.register(fastifySwagger, {
+  openapi: {
+    info: {
+      title: 'SampleApi',
+      description: 'Sample backend service',
+      version: '1.0.0',
+    },
+    servers: [],
+  },
+  transform: jsonSchemaTransform,
+  transformObject: createJsonSchemaTransformObject({
+    schemas: {
+      User: USER_SCHEMA,
+    },
+  }),
+});
+
+app.register(fastifySwaggerUI, {
+  routePrefix: '/documentation',
+});
+
+app.after(() => {
+  app.withTypeProvider<ZodTypeProvider>().route({
+    method: 'GET',
+    url: '/users',
+    schema: {
+      response: {
+        200: USER_SCHEMA.array(),
+      },
+    },
+    handler: (req, res) => {
+      res.send([]);
     },
   });
 });

--- a/README.md
+++ b/README.md
@@ -67,11 +67,23 @@ app.register(fastifySwagger, {
     servers: [],
   },
   transform: jsonSchemaTransform,
+
   // You can also create transform with custom skiplist of endpoints that should not be included in the specification:
   //
   // transform: createJsonSchemaTransform({
   //   skipList: [ '/documentation/static/*' ]
   // })
+
+  // In order to create refs to the schemas, you need to provide the schemas to the transformObject using createJsonSchemaTransformObject
+  //
+  // transformObject: createJsonSchemaTransformObject({
+  //    schemas: {
+  //      User: z.object({
+  //        id: z.string(),
+  //        name: z.string(),
+  //      }),
+  //    }
+  // }),
 });
 
 app.register(fastifySwaggerUI, {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "fastify": "^4.27.0",
     "fastify-plugin": "^4.5.1",
     "oas-validator": "^5.0.8",
+    "openapi-types": "^12.1.3",
     "prettier": "^3.2.5",
     "tsd": "^0.31.0",
     "typescript": "^5.4.5",

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -64,7 +64,7 @@ export const resolveRefs = (
   const componentMapVK = createComponentMap(schemas);
   const componentReplacer = createComponentReplacer(componentMapVK, document.components.schemas);
 
-  // Using the componetReplacer function we deep check if the document has any schemas that are the same as the zod schemas provided
+  // Using the componentReplacer function we deep check if the document has any schemas that are the same as the zod schemas provided
   // When a match is found replace them with a $ref.
   return JSON.parse(JSON.stringify(document, componentReplacer));
 };

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,0 +1,70 @@
+import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+import type { z } from 'zod';
+
+import { convertZodToJsonSchema } from './zod-to-json';
+
+const createComponentMap = (
+  schemas: Record<string, OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject>,
+) => {
+  const map = new Map<string, string>();
+
+  Object.entries(schemas).forEach(([key, value]) => map.set(JSON.stringify(value), key));
+
+  return map;
+};
+
+const createComponentReplacer = (componentMapVK: Map<string, string>, schemasObject: object) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function componentReplacer(this: any, key: string, value: any) {
+    if (typeof value !== 'object') return value;
+
+    // Check if the parent is the schemas object, if so, return the value as is. This is where the schemas are defined.
+    if (this === schemasObject) return value;
+
+    const stringifiedValue = JSON.stringify(value);
+    if (componentMapVK.has(stringifiedValue))
+      return { $ref: `#/components/schemas/${componentMapVK.get(stringifiedValue)}` };
+
+    if (value.nullable === true) {
+      const nonNullableValue = { ...value };
+      delete nonNullableValue.nullable;
+      const stringifiedNonNullableValue = JSON.stringify(nonNullableValue);
+      if (componentMapVK.has(stringifiedNonNullableValue))
+        return {
+          anyOf: [
+            { $ref: `#/components/schemas/${componentMapVK.get(stringifiedNonNullableValue)}` },
+          ],
+          nullable: true,
+        };
+    }
+
+    return value;
+  };
+
+export const resolveRefs = (
+  openapiObject: Partial<OpenAPIV3.Document | OpenAPIV3_1.Document>,
+  zodSchemas: Record<string, z.ZodTypeAny>,
+) => {
+  const schemas: Record<string, OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject> = {};
+  for (const key in zodSchemas) {
+    schemas[key] = convertZodToJsonSchema(zodSchemas[key]);
+  }
+
+  const document = {
+    ...openapiObject,
+    components: {
+      ...openapiObject.components,
+      schemas: {
+        ...openapiObject.components?.schemas,
+        ...schemas,
+      },
+    },
+  };
+
+  const componentMapVK = createComponentMap(schemas);
+  const componentReplacer = createComponentReplacer(componentMapVK, document.components.schemas);
+
+  // Using the componetReplacer function we deep check if the document has any schemas that are the same as the zod schemas provided
+  // When a match is found replace them with a $ref.
+  return JSON.parse(JSON.stringify(document, componentReplacer));
+};

--- a/src/zod-to-json.ts
+++ b/src/zod-to-json.ts
@@ -1,0 +1,11 @@
+import type { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+const zodToJsonSchemaOptions = {
+  target: 'openApi3',
+  $refStrategy: 'none',
+} as const;
+
+export const convertZodToJsonSchema = (zodSchema: z.ZodTypeAny) => {
+  return zodToJsonSchema(zodSchema, zodToJsonSchemaOptions);
+};

--- a/test/__snapshots__/fastify-swagger.spec.ts.snap
+++ b/test/__snapshots__/fastify-swagger.spec.ts.snap
@@ -123,6 +123,61 @@ exports[`transformer > generates types for fastify-swagger correctly 1`] = `
 }
 `;
 
+exports[`transformer > should generate ref correctly 1`] = `
+{
+  "components": {
+    "schemas": {
+      "Token": {
+        "maxLength": 12,
+        "minLength": 12,
+        "type": "string",
+      },
+    },
+  },
+  "info": {
+    "description": "Sample backend service",
+    "title": "SampleApi",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/login": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "access_token": {
+                    "$ref": "#/components/schemas/Token",
+                  },
+                  "refresh_token": {
+                    "$ref": "#/components/schemas/Token",
+                  },
+                },
+                "required": [
+                  "access_token",
+                  "refresh_token",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+          },
+        },
+      },
+    },
+  },
+  "servers": [],
+}
+`;
+
 exports[`transformer > should not generate ref 1`] = `
 {
   "components": {

--- a/test/fastify-swagger.spec.ts
+++ b/test/fastify-swagger.spec.ts
@@ -5,7 +5,12 @@ import * as validator from 'oas-validator';
 import { z } from 'zod';
 
 import type { ZodTypeProvider } from '../src';
-import { jsonSchemaTransform, serializerCompiler, validatorCompiler } from '../src';
+import {
+  createJsonSchemaTransformObject,
+  jsonSchemaTransform,
+  serializerCompiler,
+  validatorCompiler,
+} from '../src';
 
 describe('transformer', () => {
   it('generates types for fastify-swagger correctly', async () => {
@@ -117,6 +122,59 @@ describe('transformer', () => {
     });
 
     const TOKEN_SCHEMA = z.string().length(12);
+
+    app.after(() => {
+      app.withTypeProvider<ZodTypeProvider>().route({
+        method: 'POST',
+        url: '/login',
+        schema: {
+          body: z.object({
+            access_token: TOKEN_SCHEMA,
+            refresh_token: TOKEN_SCHEMA,
+          }),
+        },
+        handler: (req, res) => {
+          res.send('ok');
+        },
+      });
+    });
+
+    await app.ready();
+
+    const openApiSpecResponse = await app.inject().get('/documentation/json');
+    const openApiSpec = JSON.parse(openApiSpecResponse.body);
+
+    expect(openApiSpec).toMatchSnapshot();
+    await validator.validate(openApiSpec, {});
+  });
+
+  it('should generate ref correctly', async () => {
+    const app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    const TOKEN_SCHEMA = z.string().length(12);
+
+    app.register(fastifySwagger, {
+      openapi: {
+        info: {
+          title: 'SampleApi',
+          description: 'Sample backend service',
+          version: '1.0.0',
+        },
+        servers: [],
+      },
+      transform: jsonSchemaTransform,
+      transformObject: createJsonSchemaTransformObject({
+        schemas: {
+          Token: TOKEN_SCHEMA,
+        },
+      }),
+    });
+
+    app.register(fastifySwaggerUI, {
+      routePrefix: '/documentation',
+    });
 
     app.after(() => {
       app.withTypeProvider<ZodTypeProvider>().route({

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -7,7 +7,7 @@ import type {
 } from 'fastify';
 import Fastify from 'fastify';
 import { expectAssignable, expectType } from 'tsd';
-import z from 'zod';
+import { z } from 'zod';
 
 import { serializerCompiler, validatorCompiler } from '../src/index';
 import type { ZodTypeProvider } from '../src/index';


### PR DESCRIPTION
This PR adds refs to component schemas in the swagger docs.

An example on how to use refs:
```
const schemas = {
    Category: z.object({ ... }),
    Group: z.object({ ... }),
    User: z.object({ ... }),
} as const

(async () => {

    try {

        const app = fastify()
        app.setValidatorCompiler(validatorCompiler)
        app.setSerializerCompiler(serializerCompiler)

        await app.register(swagger, {
            transform: jsonSchemaTransform,
            transformObject: createJsonSchemaTransformObject({ schemas }),
        })

        await app.register(router)

        await app.ready()

        const docs = app.swagger()

        await app.close()

        const filePath = path.resolve('../openapi.json')

        await fs.promises.writeFile(filePath, JSON.stringify(docs, null, 4))

        console.log(`Docs exported to ${filePath}`)

        process.exit(0)

    } catch (e) {

        console.error(e)

        process.exit(1)

    }

})()
```

This will create an openapi spec with objects: "Category", "Group" and "User", all the schemas that use these objects will have a ref created.