### PR TITLE
Add replacer option to serializerCompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,40 @@ app.withTypeProvider<ZodTypeProvider>().route({
 app.listen({ port: 4949 });
 ```
 
+You can also pass options to the `serializerCompiler` function:
+
+```ts
+type ZodSerializerCompilerOptions = {
+  replacer?: ReplacerFunction;
+};
+```
+
+```js
+import Fastify from "fastify";
+import { createSerializerCompiler, validatorCompiler } from "fastify-type-provider-zod";
+import z from "zod";
+
+const app = Fastify()
+
+// Create a custom serializer compiler
+const customSerializerCompiler = createSerializerCompiler({
+  replacer: (key, value) => {
+    if (value instanceof Date) {
+      return { _date: value.toISOString() };
+    }
+    return value;
+  },
+});
+
+// Add schema validator and serializer
+app.setValidatorCompiler(validatorCompiler);
+app.setSerializerCompiler(customSerializerCompiler);
+
+// ...
+
+app.listen({ port: 4949 });
+```
+
 ## How to use together with @fastify/swagger
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ import z from "zod";
 
 const app = Fastify()
 
+const replacer = function (key, value) {
+  if (this[key] instanceof Date) {
+    return { _date: value.toISOString() };
+  }
+  return value;
+}
+
 // Create a custom serializer compiler
-const customSerializerCompiler = createSerializerCompiler({
-  replacer: (key, value) => {
-    if (value instanceof Date) {
-      return { _date: value.toISOString() };
-    }
-    return value;
-  },
-});
+const customSerializerCompiler = createSerializerCompiler({ replacer });
 
 // Add schema validator and serializer
 app.setValidatorCompiler(validatorCompiler);

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ type ZodSerializerCompilerOptions = {
 ```
 
 ```js
-import Fastify from "fastify";
-import { createSerializerCompiler, validatorCompiler } from "fastify-type-provider-zod";
-import z from "zod";
+import Fastify from 'fastify';
+import { createSerializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import z from 'zod';
 
-const app = Fastify()
+const app = Fastify();
 
 const replacer = function (key, value) {
   if (this[key] instanceof Date) {
     return { _date: value.toISOString() };
   }
   return value;
-}
+};
 
 // Create a custom serializer compiler
 const customSerializerCompiler = createSerializerCompiler({ replacer });

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ export {
   type ZodTypeProvider,
   type FastifyPluginAsyncZod,
   type FastifyPluginCallbackZod,
+  type ZodSerializerCompilerOptions,
   jsonSchemaTransform,
   createJsonSchemaTransform,
   createJsonSchemaTransformObject,

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ export {
   createJsonSchemaTransformObject,
   serializerCompiler,
   validatorCompiler,
+  createSerializerCompiler,
 } from './src/core';
 
 export { ResponseSerializationError, InvalidSchemaError } from './src/errors';

--- a/src/core.ts
+++ b/src/core.ts
@@ -129,9 +129,17 @@ function resolveSchema(maybeSchema: z.ZodTypeAny | { properties: z.ZodTypeAny })
   throw new InvalidSchemaError(JSON.stringify(maybeSchema));
 }
 
-export const serializerCompiler: FastifySerializerCompiler<
-  z.ZodTypeAny | { properties: z.ZodTypeAny }
-> =
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ReplacerFunction = (this: any, key: string, value: any) => any;
+
+type ZodSerializerCompilerOptions = {
+  replacer?: ReplacerFunction;
+};
+
+export const createSerializerCompiler =
+  (
+    options?: ZodSerializerCompilerOptions,
+  ): FastifySerializerCompiler<z.ZodTypeAny | { properties: z.ZodTypeAny }> =>
   ({ schema: maybeSchema, method, url }) =>
   (data) => {
     const schema = resolveSchema(maybeSchema);
@@ -141,8 +149,10 @@ export const serializerCompiler: FastifySerializerCompiler<
       throw new ResponseSerializationError(result.error, method, url);
     }
 
-    return JSON.stringify(result.data);
+    return JSON.stringify(result.data, options?.replacer);
   };
+
+export const serializerCompiler = createSerializerCompiler({});
 
 /**
  * FastifyPluginCallbackZod with Zod automatic type inference

--- a/src/core.ts
+++ b/src/core.ts
@@ -132,7 +132,7 @@ function resolveSchema(maybeSchema: z.ZodTypeAny | { properties: z.ZodTypeAny })
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ReplacerFunction = (this: any, key: string, value: any) => any;
 
-type ZodSerializerCompilerOptions = {
+export type ZodSerializerCompilerOptions = {
   replacer?: ReplacerFunction;
 };
 


### PR DESCRIPTION
This is my final addition to the type provider. I use this to serialize dates like this:

```
import { createSerializerCompiler } from 'fastify-type-provider-zod'

// eslint-disable-next-line @typescript-eslint/no-explicit-any
export function replacer(this: any, key: string, value: any) {
    if (this[key] instanceof Date) {
        return {
            _type: 'date',
            value,
        }
    }
    return value
}

export const serializerCompiler = createSerializerCompiler({ replacer })
```