### PR TITLE
types: Refactor error type in hasZodFastifySchemaValidationErrors function

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -51,7 +51,7 @@ const isZodFastifySchemaValidationError = (
 
 export const hasZodFastifySchemaValidationErrors = (
   error: unknown,
-): error is FastifyError & { validation: ZodFastifySchemaValidationError[] } =>
+): error is Omit<FastifyError, 'validation'> & { validation: ZodFastifySchemaValidationError[] } =>
   typeof error === 'object' &&
   error !== null &&
   'validation' in error &&

--- a/types/error.test-d.ts
+++ b/types/error.test-d.ts
@@ -1,6 +1,15 @@
 import type { FastifySchemaValidationError } from 'fastify/types/schema';
 import { expectAssignable } from 'tsd';
 
-import type { ZodFastifySchemaValidationError } from '../src/errors';
+import { hasZodFastifySchemaValidationErrors, type ZodFastifySchemaValidationError } from '../src/errors';
 
 expectAssignable<FastifySchemaValidationError>({} as ZodFastifySchemaValidationError);
+
+const error: unknown = {};
+if (hasZodFastifySchemaValidationErrors(error)) {
+  expectAssignable<ZodFastifySchemaValidationError>(error.validation[0]);
+
+  error.validation.forEach((validationError) => {
+    expectAssignable<ZodFastifySchemaValidationError>(validationError);
+  })
+}


### PR DESCRIPTION
The validation type was incorrect:
![image](https://github.com/user-attachments/assets/8934ccca-03a4-4154-bd8d-094c23490b37)

It caused the message to potentially be undefined:
![image](https://github.com/user-attachments/assets/8f7de40b-84fb-46b8-90c4-b6f14becabdb)
