### PR TITLE
fix: allow openapi schema

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -10,7 +10,7 @@ import type {
 } from 'fastify'
 import type { FastifySerializerCompiler } from 'fastify/types/schema'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types'
-import type { z } from 'zod'
+import { ZodSchema, type z } from 'zod'
 
 import { InvalidSchemaError, ResponseSerializationError, createValidationError } from './errors'
 import { resolveRefs } from './ref'
@@ -70,10 +70,14 @@ export const createJsonSchemaTransform = ({ skipList }: { skipList: readonly str
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       for (const prop in response as any) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const schema = resolveSchema((response as any)[prop])
+        const responseSchema = response[prop]
 
-        const transformedResponse = convertZodToJsonSchema(schema)
+        if (responseSchema instanceof ZodSchema === false) {
+          transformed.response[prop] = responseSchema
+          continue
+        }
+
+        const transformedResponse = convertZodToJsonSchema(responseSchema)
         transformed.response[prop] = transformedResponse
       }
     }

--- a/test/__snapshots__/fastify-swagger.spec.ts.snap
+++ b/test/__snapshots__/fastify-swagger.spec.ts.snap
@@ -80,6 +80,37 @@ exports[`transformer > generates types for fastify-swagger correctly 1`] = `
             },
             "description": "Default Response",
           },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Successful response",
+                  "properties": {
+                    "hello": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {
+              "Set-Cookie": {
+                "description": "Cookies for session and refresh tokens",
+                "schema": {
+                  "items": {
+                    "example": [
+                      "refreshToken=tokenValue; Path=/; HttpOnly; Secure; SameSite=Strict",
+                      "sessionToken=tokenValue; Path=/; HttpOnly; Secure; SameSite=Strict",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+          },
           "401": {
             "content": {
               "application/json": {

--- a/test/fastify-swagger.spec.ts
+++ b/test/fastify-swagger.spec.ts
@@ -63,6 +63,26 @@ describe('transformer', () => {
             response: {
               200: z.string(),
               401: UNAUTHORIZED_SCHEMA,
+              201: {
+                description: 'Successful response',
+                type: 'object',
+                properties: {
+                  hello: { type: 'string' },
+                },
+                headers: {
+                  'Set-Cookie': {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                      example: [
+                        'refreshToken=tokenValue; Path=/; HttpOnly; Secure; SameSite=Strict',
+                        'sessionToken=tokenValue; Path=/; HttpOnly; Secure; SameSite=Strict',
+                      ],
+                    },
+                    description: 'Cookies for session and refresh tokens',
+                  },
+                },
+              },
             },
           },
           handler: (req, res) => {


### PR DESCRIPTION
fixes #127

We can allow users to use raw openapi schema by skipping schema transformation if the schema is not instance of zod.