### PR TITLE
fix: update schema generation using `JSONSchemaGenerator` from zod core

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@fastify/swagger": ">=9.5.1",
     "fastify": "^5.0.0",
-    "zod": ">=3.25.56"
+    "zod": ">=3.25.67"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
@@ -58,7 +58,7 @@
     "typescript": "^5.8.3",
     "unplugin-isolated-decl": "^0.14.3",
     "vitest": "^3.2.2",
-    "zod": "^3.25.56"
+    "zod": "^3.25.67"
   },
   "tsd": {
     "directory": "types"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     minify: false,
     sourcemap: true,
     rollupOptions: {
-      external: ["fastify", "zod/v4", "@fastify/swagger", "@fastify/error"],
+      external: ["fastify", /zod\/v4*?/,  "@fastify/swagger", "@fastify/error"],
       output: [{
         preserveModules: true,
         entryFileNames: 'cjs/[name].cjs',


### PR DESCRIPTION
- Followup of https://github.com/turkerdev/fastify-type-provider-zod/pull/174#issuecomment-2992184071

It appears that Zod has removed the `external` option when working with the `toJSONSchema` methods:
- https://github.com/colinhacks/zod/commit/72623011510be94e37fdc669e1bdecc983987edb

---

[Code reference in the Zod repo](https://github.com/colinhacks/zod/blob/0a49fa39348b7c72b19ddedc3b0f879bd395304b/packages/zod/src/v4/core/to-json-schema.ts#L790-L793):

```ts
interface ToJSONSchemaParams extends Omit<JSONSchemaGeneratorParams & EmitParams, "external"> {}
interface RegistryToJSONSchemaParams extends Omit<JSONSchemaGeneratorParams & EmitParams, "external"> {
  uri?: (id: string) => string;
}
```

---

## Impact

### `zodRegistryToJson`

No issues detected.
The `external` functionality can now rely on `RegistryToJSONSchemaParams`, which introduces a new `uri` property that is already in use.

### `zodSchemaToJson`

~~The `z.toJSONSchema` method no longer provides a way to inject external references.
To replicate the previous behavior, I had to switch to using the `JSONSchemaGenerator` exported from `zod/v4/core`.~~

[New implementation](https://github.com/turkerdev/fastify-type-provider-zod/pull/175#discussion_r2159792329)
