### PR TITLE
feat: support both zod/v4 & zod/v4-mini

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -10,7 +10,7 @@ import type {
   RawServerDefault,
 } from 'fastify'
 import type { FastifySerializerCompiler } from 'fastify/types/schema'
-import { z } from 'zod/v4'
+import { $ZodRegistry, $ZodType, globalRegistry, input, output, safeParse } from 'zod/v4/core'
 
 import { createValidationError, InvalidSchemaError, ResponseSerializationError } from './errors'
 import { zodRegistryToJson, zodSchemaToJson } from './zod-to-json'
@@ -28,8 +28,8 @@ const defaultSkipList = [
 ]
 
 export interface ZodTypeProvider extends FastifyTypeProvider {
-  validator: this['schema'] extends z.ZodTypeAny ? z.output<this['schema']> : unknown
-  serializer: this['schema'] extends z.ZodTypeAny ? z.input<this['schema']> : unknown
+  validator: this['schema'] extends $ZodType ? output<this['schema']> : unknown
+  serializer: this['schema'] extends $ZodType ? input<this['schema']> : unknown
 }
 
 interface Schema extends FastifySchema {
@@ -38,12 +38,12 @@ interface Schema extends FastifySchema {
 
 type CreateJsonSchemaTransformOptions = {
   skipList?: readonly string[]
-  schemaRegistry?: z.core.$ZodRegistry<{ id?: string | undefined }>
+  schemaRegistry?: $ZodRegistry<{ id?: string | undefined }>
 }
 
 export const createJsonSchemaTransform = ({
   skipList = defaultSkipList,
-  schemaRegistry = z.globalRegistry,
+  schemaRegistry = globalRegistry,
 }: CreateJsonSchemaTransformOptions): SwaggerTransform<Schema> => {
   return ({ schema, url }) => {
     if (!schema) {
@@ -95,12 +95,12 @@ export const createJsonSchemaTransform = ({
 export const jsonSchemaTransform: SwaggerTransform<Schema> = createJsonSchemaTransform({})
 
 type CreateJsonSchemaTransformObjectOptions = {
-  schemaRegistry?: z.core.$ZodRegistry<{ id?: string | undefined }>
+  schemaRegistry?: $ZodRegistry<{ id?: string | undefined }>
 }
 
 export const createJsonSchemaTransformObject =
   ({
-    schemaRegistry = z.globalRegistry,
+    schemaRegistry = globalRegistry,
   }: CreateJsonSchemaTransformObjectOptions): SwaggerTransformObject =>
   (input) => {
     if ('swaggerObject' in input) {
@@ -134,10 +134,10 @@ export const createJsonSchemaTransformObject =
 
 export const jsonSchemaTransformObject: SwaggerTransformObject = createJsonSchemaTransformObject({})
 
-export const validatorCompiler: FastifySchemaCompiler<z.ZodTypeAny> =
+export const validatorCompiler: FastifySchemaCompiler<$ZodType> =
   ({ schema }) =>
   (data) => {
-    const result = schema.safeParse(data)
+    const result = safeParse(schema, data)
     if (result.error) {
       return { error: createValidationError(result.error) as unknown as Error }
     }
@@ -145,11 +145,11 @@ export const validatorCompiler: FastifySchemaCompiler<z.ZodTypeAny> =
     return { value: result.data }
   }
 
-function resolveSchema(maybeSchema: z.ZodTypeAny | { properties: z.ZodTypeAny }): z.ZodTypeAny {
-  if ('safeParse' in maybeSchema) {
+function resolveSchema(maybeSchema: $ZodType | { properties: $ZodType }): $ZodType {
+  if (maybeSchema instanceof $ZodType) {
     return maybeSchema
   }
-  if ('properties' in maybeSchema) {
+  if ('properties' in maybeSchema && maybeSchema.properties instanceof $ZodType) {
     return maybeSchema.properties
   }
   throw new InvalidSchemaError(JSON.stringify(maybeSchema))
@@ -164,12 +164,12 @@ export type ZodSerializerCompilerOptions = {
 export const createSerializerCompiler =
   (
     options?: ZodSerializerCompilerOptions,
-  ): FastifySerializerCompiler<z.ZodTypeAny | { properties: z.ZodTypeAny }> =>
+  ): FastifySerializerCompiler<$ZodType | { properties: $ZodType }> =>
   ({ schema: maybeSchema, method, url }) =>
   (data) => {
     const schema = resolveSchema(maybeSchema)
 
-    const result = schema.safeParse(data)
+    const result = safeParse(schema, data)
     if (result.error) {
       throw new ResponseSerializationError(method, url, { cause: result.error })
     }

--- a/src/core.ts
+++ b/src/core.ts
@@ -10,7 +10,8 @@ import type {
   RawServerDefault,
 } from 'fastify'
 import type { FastifySerializerCompiler } from 'fastify/types/schema'
-import { $ZodRegistry, $ZodType, globalRegistry, input, output, safeParse } from 'zod/v4/core'
+import type { $ZodRegistry, input, output } from 'zod/v4/core'
+import { $ZodType, globalRegistry, safeParse } from 'zod/v4/core'
 
 import { createValidationError, InvalidSchemaError, ResponseSerializationError } from './errors'
 import { zodRegistryToJson, zodSchemaToJson } from './zod-to-json'

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,7 @@
 import createError, { type FastifyErrorConstructor } from '@fastify/error'
 import type { FastifyError } from 'fastify'
 import type { FastifySchemaValidationError } from 'fastify/types/schema'
-import type { z } from 'zod/v4'
+import type { $ZodError } from 'zod/v4/core'
 
 export const InvalidSchemaError: FastifyErrorConstructor<
   {
@@ -22,22 +22,22 @@ const ResponseSerializationBase: FastifyErrorConstructor<
   },
   [
     {
-      cause: z.ZodError
+      cause: $ZodError
     },
   ]
-> = createError<[{ cause: z.ZodError }]>(
+> = createError<[{ cause: $ZodError }]>(
   'FST_ERR_RESPONSE_SERIALIZATION',
   "Response doesn't match the schema",
   500,
 )
 
 export class ResponseSerializationError extends ResponseSerializationBase {
-  cause!: z.ZodError
+  cause!: $ZodError
 
   constructor(
     public method: string,
     public url: string,
-    options: { cause: z.ZodError },
+    options: { cause: $ZodError },
   ) {
     super({ cause: options.cause })
 
@@ -83,7 +83,7 @@ function omit<T extends object, K extends keyof T>(obj: T, keys: readonly K[]): 
   return result
 }
 
-export function createValidationError(error: z.ZodError): ZodFastifySchemaValidationError[] {
+export function createValidationError(error: $ZodError): ZodFastifySchemaValidationError[] {
   return error.issues.map((issue) => {
     return {
       [ZodFastifySchemaValidationErrorSymbol]: true,

--- a/src/zod-to-json.ts
+++ b/src/zod-to-json.ts
@@ -1,4 +1,5 @@
-import { $ZodDate, $ZodRegistry, $ZodType, JSONSchema, toJSONSchema } from 'zod/v4/core'
+import type { $ZodDate, $ZodRegistry, JSONSchema } from 'zod/v4/core'
+import { $ZodType, toJSONSchema } from 'zod/v4/core'
 
 const getSchemaId = (id: string, io: 'input' | 'output') => {
   return io === 'input' ? `${id}Input` : id

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     minify: false,
     sourcemap: true,
     rollupOptions: {
-      external: ["fastify", "zod/v4", "@fastify/swagger", "@fastify/error"],
+      external: ["fastify", "zod/v4", "zod/v4/core", "zod/v4-mini", "@fastify/swagger", "@fastify/error"],
       output: [{
         preserveModules: true,
         entryFileNames: 'cjs/[name].cjs',


### PR DESCRIPTION
This pull request updates the codebase to use `zod/v4/core` API instead, replacing previous imports and types from `zod/v4`. The changes ensure compatibility with both `zod/v4` & `zod/v4-mini` as recommended in Zod official documentation for library authors.