### PR TITLE
Revert "Bump @biomejs/biome from 1.9.4 to 2.0.5 (#177)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "zod": ">=3.25.56"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.5",
+    "@biomejs/biome": "^1.9.4",
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.3",
     "@kibertoad/biome-config": "^1.2.1",

--- a/src/zod-to-json.ts
+++ b/src/zod-to-json.ts
@@ -45,6 +45,7 @@ export const zodSchemaToJson: (
   registry: z.core.$ZodRegistry<{ id?: string }>,
   io: 'input' | 'output',
 ) => ReturnType<typeof deleteInvalidProperties> = (zodSchema, registry, io) => {
+  // @ts-expect-error
   const result = z.toJSONSchema(zodSchema, {
     io,
     unrepresentable: 'any',
@@ -52,7 +53,7 @@ export const zodSchemaToJson: (
     reused: 'inline',
     external: {
       registry,
-      uri: (id) => getReferenceUri(id, io),
+      uri: (id: string) => getReferenceUri(id, io),
       defs: {},
     },
     override: (ctx) => getOverride(ctx, io),
@@ -67,6 +68,7 @@ export const zodRegistryToJson: (
   registry: z.core.$ZodRegistry<{ id?: string }>,
   io: 'input' | 'output',
 ) => Record<string, z.core.JSONSchema.BaseSchema> = (registry, io) => {
+  // @ts-expect-error
   const result = z.toJSONSchema(registry, {
     io,
     unrepresentable: 'any',
@@ -75,7 +77,7 @@ export const zodRegistryToJson: (
     uri: (id) => getReferenceUri(id, io),
     external: {
       registry,
-      uri: (id) => getReferenceUri(id, io),
+      uri: (id: string) => getReferenceUri(id, io),
       defs: {},
     },
     override: (ctx) => getOverride(ctx, io),


### PR DESCRIPTION
- reverts  9c9431c5bc002dcb23f6efe9cbc422d5a692990b.

Right now CI is broken due to biome update to v2 without updating the configuration:

https://github.com/turkerdev/fastify-type-provider-zod/actions/runs/15916652065/job/44895402215?pr=175

Updating local config isn't suffice since  [kibertoad/biome-config](https://github.com/kibertoad/biome-config) doesn't support biome v2 yet,
so we should stick to biome 1.9.x until then. 
