### PR TITLE
Update REAMDE to use zod/v4 in first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ```ts
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
-import z from 'zod/v4';
+import { z } from 'zod/v4';
 
 const app = Fastify();
 


### PR DESCRIPTION
The first example in the README imports "zod" rather than "zod/v4" which I believe will throw an invalid type error with the latest version of this library.

I also ran the various code examples through ESLint/Prettier so that they use the same formatting conventions.