### PR TITLE
chore(lint): add plugin to ensure that only `zod/v4/core` is imported

### DIFF
--- a/biome-plugins/ensures-zod-core-import.grit
+++ b/biome-plugins/ensures-zod-core-import.grit
@@ -1,0 +1,12 @@
+// Ensures that only `zod/v4/core` is imported.
+// https://zod.dev/library-authors?id=how-to-support-zod-and-zod-mini-simultaneously
+// > Your library code should only import from "zod/v4/core". 
+// > This sub-package defines the interfaces, classes, and utilities that are shared between zod/v4 and zod/v4-mini.
+
+`import $imports from $source` where {
+    $source <: or {`'zod'`, `'zod/v4'`},
+    register_diagnostic(
+        span = $source,
+        message = "This plugins supports both `zod` and `zod-mini`, so please import only from `zod/v4/core`"
+    )
+}

--- a/biome.json
+++ b/biome.json
@@ -28,6 +28,10 @@
           }
         }
       }
+    },
+    {
+      "includes": ["src/**"],
+      "plugins": ["./biome-plugins/ensures-zod-core-import.grit"]
     }
   ]
 }


### PR DESCRIPTION
With the changes introduced in [https://github.com/turkerdev/fastify-type-provider-zod/pull/176](https://github.com/turkerdev/fastify-type-provider-zod/pull/176), the plugin now supports both `zod` and `zod-mini`. 
As a result, only imports from `zod/v4/core` should be used.

Biome now offers a new plugin API (currently in beta): [https://biomejs.dev/linter/plugins/](https://biomejs.dev/linter/plugins/)

This PR introduces a custom Biome plugin that enforces correct import usage within the `src` directory. 
It ensures that no invalid `zod` imports are present.

Below is an example of errors triggered by incorrect import paths:

<img width="600" alt="Screenshot 2025-06-30 at 20 34 18" src="https://github.com/user-attachments/assets/7b85d2c3-55a6-42c1-bb47-d04a60ba8f14" />

