### PR TITLE
feat: add zod 4 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "@fastify/swagger": ">=9.5.1",
     "fastify": "^5.0.0",
-    "zod": ">=3.25.67"
+    "zod": "^3.25.67 || ^4.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",


### PR DESCRIPTION
https://github.com/colinhacks/zod/releases/tag/v4.0.1

> Library authors — if you've already implemented Zod 4 support according to the best practices outlined in the [Library authors](https://github.com/colinhacks/zod/blob/v4.0.1/library-authors) guide, bump your peer dependency to include zod@^4.0.0:
> ```jsonc
> // package.json
> {
>   "peerDependencies": {
>     "zod": "^3.25.0 || ^4.0.0"
>   }
> }
>```
> There should be no other code changes necessary. No code changes were made between the latest 3.25.x release and > 4.0.0. This does not require a major version bump.