### PR TITLE
fix(zod-to-json): handle `anyOf` with more than 2 items

### DIFF
--- a/test/__snapshots__/fastify-swagger.spec.ts.snap
+++ b/test/__snapshots__/fastify-swagger.spec.ts.snap
@@ -113,6 +113,90 @@ exports[`transformer > generates types for fastify-swagger correctly 1`] = `
 }
 `;
 
+exports[`transformer > null type > should replace \`anyOf\` when it contains 2 elements: \`{ anyOf: [<null>, <non-null>]} s\` and one of them is \`"type": "null" with \`{...<non-null>, nullable: true }\` 1`] = `
+{
+  "components": {
+    "schemas": {},
+  },
+  "info": {
+    "description": "Sample backend service",
+    "title": "SampleApi",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "enum": [
+                        "any",
+                      ],
+                      "type": "string",
+                    },
+                  ],
+                  "nullable": true,
+                },
+              },
+            },
+            "description": "Default Response",
+          },
+        },
+      },
+    },
+  },
+  "servers": [],
+}
+`;
+
+exports[`transformer > null type > should replace \`anyOf\` with \`"allOf": [...], "nullable": true\`  when schema contains only two elements and one is \`"type": "null"\` 1`] = `
+{
+  "components": {
+    "schemas": {},
+  },
+  "info": {
+    "description": "Sample backend service",
+    "title": "SampleApi",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string",
+                  },
+                  "nullable": true,
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Default Response",
+          },
+        },
+      },
+    },
+  },
+  "servers": [],
+}
+`;
+
 exports[`transformer > should generate input and output schemas correctly 1`] = `
 {
   "components": {
@@ -602,6 +686,7 @@ exports[`transformer > should not generate ref 1`] = `
                     "type": "string",
                   },
                   "age": {
+                    "minimum": 0,
                     "nullable": true,
                     "type": "number",
                   },


### PR DESCRIPTION
- fixes #192

---

This improves `anyOf` management when overriding zod schemas to produces a OpenAPI schema,

### 2 elements with one nullable

```ts
const VALUE_SCHEMA = z.union([z.null(), z.array(z.string())])
```

becomes: 

```jsonc
{
  "items": {
    "type": "string",
  },
  "nullable": true,
  "type": "array",
},
```

### >= 3 elements with one nullable

```ts
const VALUE_SCHEMA = z.union([z.null(), z.array(z.string()), z.literal('any')])
```

becomes: 

```jsonc
{
  "anyOf": [
    {
      "items": {
        "type": "string",
      },
      "type": "array",
    },
    {
      "enum": [
        "any",
      ],
      "type": "string",
    },
  ],
  "nullable": true,
}
```