### PR TITLE
refactor: cache resolved schema in serializer compiler

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -211,19 +211,19 @@ export const createSerializerCompiler =
   (
     options?: ZodSerializerCompilerOptions,
   ): FastifySerializerCompiler<$ZodType | { properties: $ZodType }> =>
-  ({ schema: maybeSchema, method, url }) =>
-  (data) => {
-    const schema = resolveSchema(maybeSchema)
+  ({ schema: maybeSchema, method, url }) => {
+    const schema = resolveSchema(maybeSchema);
+    return (data) => {
+      const result = safeParse(schema, data)
+      if (result.error) {
+        throw new ResponseSerializationError(method, url, {
+          cause: result.error,
+        })
+      }
 
-    const result = safeParse(schema, data)
-    if (result.error) {
-      throw new ResponseSerializationError(method, url, {
-        cause: result.error,
-      })
+      return JSON.stringify(result.data, options?.replacer)
     }
-
-    return JSON.stringify(result.data, options?.replacer)
-  }
+}
 
 export const serializerCompiler: ReturnType<typeof createSerializerCompiler> =
   createSerializerCompiler({})


### PR DESCRIPTION
With this change a schema for a route is resolved only once during startup instead of for every response. This also has the advantage that the `InvalidSchemaError` in `resolveSchema` gets thrown right during startup rather than after the first request.

There is an unrelated test failure (probably due to an outdated snapshot):
test/fastify-swagger.spec.ts > transformer > should generate referenced input and output schemas correctly when referencing a registered schema