### PR TITLE
feat: support content-type-specific response schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,28 @@ async function run() {
 run();
 ```
 
+## How to define an empty body response
+
+Use `z.undefined()` to define a response with no body. This enforces correct types on `res.send()` and generates an accurate OpenAPI schema:
+
+```ts
+import { z } from 'zod/v4';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+app.withTypeProvider<ZodTypeProvider>().route({
+  method: 'DELETE',
+  url: '/resource',
+  schema: {
+    response: {
+      204: z.undefined().describe('Resource deleted'),
+    },
+  },
+  handler: (_req, res) => {
+    res.status(204).send();
+  },
+});
+```
+
 ## How to define multiple response content types
 
 You can define per-content-type response schemas following the OpenAPI 3.x response object format. The `jsonSchemaTransform` will include them correctly in the generated spec, and `res.send()` will be typed as the union of all defined schemas.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,48 @@ async function run() {
 run();
 ```
 
+## How to define multiple response content types
+
+You can define per-content-type response schemas following the OpenAPI 3.x response object format. The `jsonSchemaTransform` will include them correctly in the generated spec, and `res.send()` will be typed as the union of all defined schemas.
+
+```ts
+import { z } from 'zod/v4';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+
+app.withTypeProvider<ZodTypeProvider>().route({
+  method: 'GET',
+  url: '/items',
+  schema: {
+    response: {
+      200: {
+        description: 'Successful response',
+        content: {
+          'application/json': { schema: z.object({ id: z.number(), name: z.string() }) },
+          'application/vnd.v1+json': { schema: z.array(z.object({ id: z.number(), name: z.string() })) },
+        },
+      },
+      default: {
+        content: {
+          '*/*': { schema: z.object({ message: z.string() }) },
+        },
+      },
+    },
+  },
+  handler: (req, res) => {
+    res.send({ id: 1, name: 'item' });
+  },
+});
+```
+
+Fastify dispatches serialization per content type — set the response `Content-Type` header in the handler to select which schema validates the response body:
+
+```ts
+handler: (req, res) => {
+  res.header('Content-Type', 'application/vnd.v1+json');
+  res.send([{ id: 1, name: 'item' }]);
+},
+```
+
 ## How to create a plugin?
 
 ```ts

--- a/src/core.ts
+++ b/src/core.ts
@@ -121,7 +121,9 @@ export const createJsonSchemaTransform = ({
 
           responseObj.content = {}
 
-          for (const [contentType, { schema: maybeSchema }] of Object.entries(responseSchema.content)) {
+          for (const [contentType, { schema: maybeSchema }] of Object.entries(
+            responseSchema.content,
+          )) {
             const zodSchema = resolveSchema(maybeSchema)
             const jsonSchema = zodSchemaToJson(
               zodSchema,

--- a/src/core.ts
+++ b/src/core.ts
@@ -18,6 +18,21 @@ import { type ZodToJsonConfig, zodRegistryToJson, zodSchemaToJson } from './zod-
 
 type FreeformRecord = Record<string, any>
 
+type ContentTypeResponse = {
+  description?: string
+  content: Record<string, { schema: $ZodType }>
+}
+
+const isContentTypeResponse = (maybeSchema: unknown): maybeSchema is ContentTypeResponse => {
+  return (
+    typeof maybeSchema === 'object' &&
+    maybeSchema !== null &&
+    'content' in maybeSchema &&
+    typeof maybeSchema.content === 'object' &&
+    maybeSchema.content !== null
+  )
+}
+
 const defaultSkipList = [
   '/documentation/',
   '/documentation/initOAuth',
@@ -94,8 +109,36 @@ export const createJsonSchemaTransform = ({
     if (response) {
       transformed.response = {}
 
-      for (const prop in response as any) {
-        const zodSchema = resolveSchema((response as any)[prop])
+      for (const prop in response) {
+        const responseSchema = (response as any)[prop]
+
+        if (isContentTypeResponse(responseSchema)) {
+          const responseObj: FreeformRecord = {}
+
+          if (responseSchema.description) {
+            responseObj.description = responseSchema.description
+          }
+
+          responseObj.content = {}
+
+          for (const [contentType, { schema: maybeSchema }] of Object.entries(responseSchema.content)) {
+            const zodSchema = resolveSchema(maybeSchema)
+            const jsonSchema = zodSchemaToJson(
+              zodSchema,
+              schemaRegistry,
+              'output',
+              oasVersion,
+              zodToJsonConfig,
+            )
+            const oasSchema = jsonSchemaToOAS(jsonSchema, oasVersion)
+            responseObj.content[contentType] = { schema: oasSchema }
+          }
+
+          transformed.response[prop] = responseObj
+          continue
+        }
+
+        const zodSchema = resolveSchema(responseSchema)
         const jsonSchema = zodSchemaToJson(
           zodSchema,
           schemaRegistry,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -32,7 +32,7 @@ const ResponseSerializationBase: FastifyErrorConstructor<
 )
 
 export class ResponseSerializationError extends ResponseSerializationBase {
-  cause!: $ZodError
+  declare cause: $ZodError
 
   constructor(
     public method: string,

--- a/test/__snapshots__/fastify-swagger.spec.ts.snap
+++ b/test/__snapshots__/fastify-swagger.spec.ts.snap
@@ -1024,8 +1024,7 @@ exports[`transformer > should generate referenced input and output schemas corre
                 "$ref": "#/components/schemas/UserInput",
               },
             },
-          },
-          "required": true,
+          }
         },
         "responses": {
           "200": {

--- a/test/__snapshots__/fastify-swagger.spec.ts.snap
+++ b/test/__snapshots__/fastify-swagger.spec.ts.snap
@@ -1024,7 +1024,8 @@ exports[`transformer > should generate referenced input and output schemas corre
                 "$ref": "#/components/schemas/UserInput",
               },
             },
-          }
+          },
+          "required": true,
         },
         "responses": {
           "200": {

--- a/test/__snapshots__/fastify-swagger.spec.ts.snap
+++ b/test/__snapshots__/fastify-swagger.spec.ts.snap
@@ -1,5 +1,110 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transformer > generates correct OpenAPI schema for content-type response schemas 1`] = `
+{
+  "components": {
+    "schemas": {},
+  },
+  "info": {
+    "description": "Sample backend service",
+    "title": "SampleApi",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/items": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": "number",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                  ],
+                  "type": "object",
+                },
+              },
+              "application/vnd.v1+json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "type": "number",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Successful response with multiple content types",
+          },
+          "3XX": {
+            "content": {
+              "application/vnd.v2+json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "redirect": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "redirect",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Default Response",
+          },
+          "default": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "desc": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "desc",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Default Response",
+          },
+        },
+      },
+    },
+  },
+  "servers": [],
+}
+`;
+
 exports[`transformer > generates types for fastify-swagger correctly 1`] = `
 {
   "components": {
@@ -920,6 +1025,7 @@ exports[`transformer > should generate referenced input and output schemas corre
               },
             },
           },
+          "required": true,
         },
         "responses": {
           "200": {

--- a/test/fastify-swagger.spec.ts
+++ b/test/fastify-swagger.spec.ts
@@ -939,4 +939,45 @@ describe('transformer', () => {
     expect(openApiSpec).toMatchSnapshot()
     await validator.validate(openApiSpec, {})
   })
+
+  it('generates correct OpenAPI schema for z.undefined() 204 no-body response', async () => {
+    const app = Fastify()
+    app.setValidatorCompiler(validatorCompiler)
+    app.setSerializerCompiler(serializerCompiler)
+
+    app.register(fastifySwagger, {
+      ...OPENAPI_ROOT,
+      transform: jsonSchemaTransform,
+    })
+
+    app.register(fastifySwaggerUI, { routePrefix: '/documentation' })
+
+    app.after(() => {
+      app.withTypeProvider<ZodTypeProvider>().route({
+        method: 'DELETE',
+        url: '/items/:id',
+        schema: {
+          response: {
+            204: z.undefined().describe('No content'),
+          },
+        },
+        handler: (_req, res) => {
+          res.status(204).send()
+        },
+      })
+    })
+
+    await app.ready()
+
+    const openApiSpec = JSON.parse((await app.inject().get('/documentation/json')).body)
+
+    expect(openApiSpec.paths['/items/{id}'].delete.responses).toMatchInlineSnapshot(`
+      {
+        "204": {
+          "description": "No content",
+        },
+      }
+    `)
+    await validator.validate(openApiSpec, {})
+  })
 })

--- a/test/fastify-swagger.spec.ts
+++ b/test/fastify-swagger.spec.ts
@@ -875,4 +875,68 @@ describe('transformer', () => {
       `[AssertionError: Must be an OpenAPI 3.0.x document]`,
     )
   })
+
+  it('generates correct OpenAPI schema for content-type response schemas', async () => {
+    const app = Fastify()
+    app.setValidatorCompiler(validatorCompiler)
+    app.setSerializerCompiler(serializerCompiler)
+
+    app.register(fastifySwagger, {
+      openapi: {
+        openapi: '3.0.3',
+        info: {
+          title: 'SampleApi',
+          description: 'Sample backend service',
+          version: '1.0.0',
+        },
+        servers: [],
+      },
+      transform: jsonSchemaTransform,
+    })
+
+    app.register(fastifySwaggerUI, {
+      routePrefix: '/documentation',
+    })
+
+    const ItemSchema = z.object({ id: z.number(), name: z.string() })
+
+    app.after(() => {
+      app.withTypeProvider<ZodTypeProvider>().route({
+        method: 'GET',
+        url: '/items',
+        schema: {
+          response: {
+            200: {
+              description: 'Successful response with multiple content types',
+              content: {
+                'application/json': { schema: ItemSchema },
+                'application/vnd.v1+json': { schema: z.array(ItemSchema) },
+              },
+            },
+            '3xx': {
+              content: {
+                'application/vnd.v2+json': { schema: z.object({ redirect: z.string() }) },
+              },
+            },
+            default: {
+              content: {
+                '*/*': { schema: z.object({ desc: z.string() }) },
+              },
+            },
+          },
+        },
+        handler: (_req, res) => {
+          res.send({ id: 1, name: 'item' })
+        },
+      })
+    })
+
+    await app.ready()
+
+    const openApiSpecResponse = await app.inject().get('/documentation/json')
+    const openApiSpec = JSON.parse(openApiSpecResponse.body)
+
+    expect(openApiSpec).toMatchSnapshot()
+    await validator.validate(openApiSpec, {})
+  })
 })

--- a/test/response-schema.spec.ts
+++ b/test/response-schema.spec.ts
@@ -224,6 +224,108 @@ describe('response schema', () => {
     })
   })
 
+  describe('correctly processes content-type response schema', () => {
+    let app: FastifyInstance
+    beforeAll(async () => {
+      app = Fastify()
+      app.setValidatorCompiler(validatorCompiler)
+      app.setSerializerCompiler(serializerCompiler)
+
+      app.after(() => {
+        app
+          .withTypeProvider<ZodTypeProvider>()
+          .route({
+            method: 'GET',
+            url: '/single',
+            schema: {
+              response: {
+                200: {
+                  content: {
+                    'application/json': { schema: z.object({ name: z.string() }) },
+                  },
+                },
+              },
+            },
+            handler: (_req, res) => {
+              res.send({ name: 'test' })
+            },
+          })
+          .route({
+            method: 'GET',
+            url: '/multi-content-type',
+            schema: {
+              response: {
+                200: {
+                  content: {
+                    'application/json': { schema: z.object({ type: z.literal('first') }) },
+                    'application/vnd.v1+json': { schema: z.object({ type: z.literal('second') }) },
+                  },
+                },
+              },
+            },
+            handler: (_req, res) => {
+              res.header('Content-Type', 'application/vnd.v1+json')
+              res.send({ type: 'second' })
+            },
+          })
+          .route({
+            method: 'GET',
+            url: '/incorrect',
+            schema: {
+              response: {
+                200: {
+                  content: {
+                    'application/json': { schema: z.object({ name: z.string() }) },
+                  },
+                },
+              },
+            },
+            handler: (_req, res) => {
+              // @ts-expect-error
+              res.send({ invalid: true })
+            },
+          })
+      })
+
+      app.setErrorHandler((err, _req, reply) => {
+        if (isResponseSerializationError(err)) {
+          return reply.code(500).send({
+            error: 'Internal Server Error',
+            message: "Response doesn't match the schema",
+            statusCode: 500,
+          })
+        }
+        throw err
+      })
+
+      await app.ready()
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    it('validates single content type response', async () => {
+      const response = await app.inject().get('/single')
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ name: 'test' })
+    })
+
+    it('uses matching schema when Content-Type header selects a non-default content type', async () => {
+      const response = await app.inject().get('/multi-content-type')
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ type: 'second' })
+    })
+
+    it('throws when data does not match any content type schema', async () => {
+      const response = await app.inject().get('/incorrect')
+
+      expect(response.statusCode).toBe(500)
+    })
+  })
+
   describe('correctly replaces date in stringified response', () => {
     let app: FastifyInstance
     beforeAll(async () => {

--- a/test/response-schema.spec.ts
+++ b/test/response-schema.spec.ts
@@ -38,8 +38,7 @@ describe('response schema', () => {
               },
             },
             handler: (_req, res) => {
-              // @ts-expect-error
-              res.status(204).send({ id: 1 })
+              res.status(204).send({ id: 1 } as any)
             },
           })
       })
@@ -281,7 +280,7 @@ describe('response schema', () => {
               },
             },
             handler: (_req, res) => {
-              // @ts-expect-error
+              // @ts-expect-error — intentionally sending wrong shape to test runtime serialization rejection
               res.send({ invalid: true })
             },
           })

--- a/test/response-schema.spec.ts
+++ b/test/response-schema.spec.ts
@@ -326,6 +326,44 @@ describe('response schema', () => {
     })
   })
 
+  describe('correctly processes no-content response', () => {
+    let app: FastifyInstance
+    beforeAll(async () => {
+      app = Fastify()
+      app.setValidatorCompiler(validatorCompiler)
+      app.setSerializerCompiler(serializerCompiler)
+
+      app.after(() => {
+        app
+          .withTypeProvider<ZodTypeProvider>()
+          .route({
+            method: 'DELETE',
+            url: '/resource',
+            schema: {
+              response: {
+                204: z.undefined().describe('Resource deleted'),
+              },
+            },
+            handler: (_req, res) => {
+              res.status(204).send()
+            },
+          })
+      })
+      await app.ready()
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    it('returns 204 with empty body', async () => {
+      const response = await app.inject().delete('/resource')
+
+      expect(response.statusCode).toBe(204)
+      expect(response.body).toEqual('')
+    })
+  })
+
   describe('correctly replaces date in stringified response', () => {
     let app: FastifyInstance
     beforeAll(async () => {

--- a/test/response-schema.spec.ts
+++ b/test/response-schema.spec.ts
@@ -334,20 +334,18 @@ describe('response schema', () => {
       app.setSerializerCompiler(serializerCompiler)
 
       app.after(() => {
-        app
-          .withTypeProvider<ZodTypeProvider>()
-          .route({
-            method: 'DELETE',
-            url: '/resource',
-            schema: {
-              response: {
-                204: z.undefined().describe('Resource deleted'),
-              },
+        app.withTypeProvider<ZodTypeProvider>().route({
+          method: 'DELETE',
+          url: '/resource',
+          schema: {
+            response: {
+              204: z.undefined().describe('Resource deleted'),
             },
-            handler: (_req, res) => {
-              res.status(204).send()
-            },
-          })
+          },
+          handler: (_req, res) => {
+            res.status(204).send()
+          },
+        })
       })
       await app.ready()
     })

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -44,3 +44,23 @@ fastify.route({
     res.send('string');
   },
 });
+
+fastify.route({
+  method: 'GET',
+  url: '/content-type',
+  schema: {
+    response: {
+      200: {
+        content: {
+          'application/json': { schema: z.object({ type: z.literal('first') }) },
+          'application/vnd.v1+json': { schema: z.object({ type: z.literal('second') }) },
+        },
+      },
+    },
+  },
+  handler: (_req, res) => {
+    expectType<{ type: 'first' } | { type: 'second' }>(
+      {} as Parameters<typeof res.send>[0],
+    );
+  },
+});


### PR DESCRIPTION
This PR adds support for defining multiple content-type-specific response schemas on a single route, following the OpenAPI response object format.

### Usage

```typescript
fastify.post('/url', {
  schema: {
    response: {
      200: {
        description: 'Successful response',
        content: {
          'application/json': { schema: z.object({ name: z.string() }) },
          'application/vnd.v1+json': { schema: z.array(ItemSchema) },
        },
      },
      '3xx': {
        content: {
          'application/vnd.v2+json': { schema: z.object({ redirect: z.string() }) },
        },
      },
    },
  },
})
```

Fastify dispatches serialization per content type — set the response Content-Type header in the handler to select which schema validates the response body.

### Documentation
  
The README has been updated with two new sections:

- How to define an empty body response — documents using z.undefined() to enforce an empty body and generate an accurate OpenAPI schema for no-content responses (e.g. 204).
- How to define multiple response content types — documents the per-content-type schema format with a full usage example including runtime Content-Type header selection.
