### PR TITLE
ci: add OIDC trusted-publisher publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -46,12 +46,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           advanced-security: false
           annotations: true
@@ -63,6 +63,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@d1b52cc4c7e618b19de8a43c7138213b277e820c # v3.14.0
+      - uses: fastify/github-action-merge-dependabot@73ec4cbb5e56df5591eae286972d5b2201ffe90f # v3.15.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: publish
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'minor') || contains(github.event.pull_request.labels.*.name, 'major'))
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Determine version bump
+        id: version
+        run: |
+          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
+            echo "bump=major" >> "$GITHUB_OUTPUT"
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
+            echo "bump=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "bump=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version
+        run: |
+          npm version ${{ steps.version.outputs.bump }} -m "chore: release v%s"
+          git push
+          git push --tags
+
+      - name: Publish to npm
+        run: pnpm publish --access public --no-git-checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -47,20 +48,25 @@ jobs:
 
       - name: Determine version bump
         id: version
+        env:
+          IS_MAJOR: ${{ contains(github.event.pull_request.labels.*.name, 'major') }}
+          IS_MINOR: ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}
         run: |
-          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
+          if [ "$IS_MAJOR" = "true" ]; then
             echo "bump=major" >> "$GITHUB_OUTPUT"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
+          elif [ "$IS_MINOR" = "true" ]; then
             echo "bump=minor" >> "$GITHUB_OUTPUT"
           else
             echo "bump=patch" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump version
+        env:
+          BUMP: ${{ steps.version.outputs.bump }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm version ${{ steps.version.outputs.bump }} -m "chore: release v%s"
-          git push
-          git push --tags
+          npm version "$BUMP" -m "chore: release v%s"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main --follow-tags
 
       - name: Publish to npm
         run: pnpm publish --access public --no-git-checks

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
     "prepublishOnly": "pnpm run build"
   },
   "repository": {
-    "url": "https://github.com/turkerdev/fastify-type-provider-zod"
+    "type": "git",
+    "url": "git+https://github.com/turkerdev/fastify-type-provider-zod.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "fastify",


### PR DESCRIPTION
## What

Adds a label-driven `publish` workflow, mirroring the setup in [opinionated-machine](https://github.com/kibertoad/opinionated-machine/blob/main/.github/workflows/publish.yml), adapted to this repo's conventions.

## How it works

- Triggers on a PR merged into `main` that carries a `patch`, `minor`, or `major` label.
- Bumps the version accordingly (`npm version`), pushes the commit and tag.
- Publishes to npm using **OIDC trusted publishing** (`id-token: write`), so no `NPM_TOKEN` secret is required. The npm package must have a trusted publisher configured pointing at this workflow.

## Repo-specific adjustments vs. the reference

- Uses `pnpm` for install/build/publish (this repo is pnpm-based).
- Pins actions by SHA to match `ci.yml`.
- Top-level `permissions: {}` with job-scoped `contents: write` + `id-token: write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)